### PR TITLE
fix: inject mime type and content size into file's metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4336,6 +4336,7 @@ dependencies = [
  "hex-literal",
  "lazy_static",
  "lz4_flex",
+ "mime_guess",
  "rand 0.8.5",
  "reqwest",
  "serde",
@@ -5010,7 +5011,7 @@ dependencies = [
 [[package]]
 name = "wnfs"
 version = "0.1.21"
-source = "git+https://github.com/banyancomputer/rs-wnfs#58ff78b85c2c7bc5c1a690265e4e60ad4f5d6672"
+source = "git+https://github.com/banyancomputer/rs-wnfs?branch=main#b6955f284343d418e6ae229209a2d07760c50bd7"
 dependencies = [
  "aes-gcm",
  "aes-kw",
@@ -5040,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "wnfs-common"
 version = "0.1.21"
-source = "git+https://github.com/banyancomputer/rs-wnfs#58ff78b85c2c7bc5c1a690265e4e60ad4f5d6672"
+source = "git+https://github.com/banyancomputer/rs-wnfs?branch=main#b6955f284343d418e6ae229209a2d07760c50bd7"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -5058,7 +5059,7 @@ dependencies = [
 [[package]]
 name = "wnfs-hamt"
 version = "0.1.21"
-source = "git+https://github.com/banyancomputer/rs-wnfs#58ff78b85c2c7bc5c1a690265e4e60ad4f5d6672"
+source = "git+https://github.com/banyancomputer/rs-wnfs?branch=main#b6955f284343d418e6ae229209a2d07760c50bd7"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -5082,7 +5083,7 @@ dependencies = [
 [[package]]
 name = "wnfs-namefilter"
 version = "0.1.21"
-source = "git+https://github.com/banyancomputer/rs-wnfs#58ff78b85c2c7bc5c1a690265e4e60ad4f5d6672"
+source = "git+https://github.com/banyancomputer/rs-wnfs?branch=main#b6955f284343d418e6ae229209a2d07760c50bd7"
 dependencies = [
  "anyhow",
  "async-once-cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tomb-crypt = { git = "https://github.com/banyancomputer/tomb-crypt", branch = "m
 
 # For local dev if needed..
 #wnfs = { path = "../rs-wnfs/wnfs" }
-wnfs = { git = "https://github.com/banyancomputer/rs-wnfs", version = "0.1.20" }
+wnfs = { git = "https://github.com/banyancomputer/rs-wnfs", branch = "main" }
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tomb-crypt = { git = "https://github.com/banyancomputer/tomb-crypt", branch = "m
 
 # For local dev if needed..
 #wnfs = { path = "../rs-wnfs/wnfs" }
-wnfs = { git = "https://github.com/banyancomputer/rs-wnfs", branch = "main" }
+wnfs = { git = "https://github.com/banyancomputer/rs-wnfs", branch = "main", version = "0.1.20" }
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/tomb-common/Cargo.toml
+++ b/tomb-common/Cargo.toml
@@ -35,6 +35,7 @@ wasm-bindgen = "^0.2"
 unsigned-varint = "^0.7"
 bytes = "1.5.0"
 async-recursion = "1.0.5"
+mime_guess = "^2"
 
 [dev-dependencies]
 fs_extra = { workspace = true }

--- a/tomb-common/src/metadata.rs
+++ b/tomb-common/src/metadata.rs
@@ -518,7 +518,9 @@ impl FsMetadata {
         content: Vec<u8>,
     ) -> Result<()> {
         let time = Utc::now();
+        let data_size = content.len();
         let mut rng = thread_rng();
+
         let result = self
             .root_dir
             .open_file_mut(
@@ -539,7 +541,16 @@ impl FsMetadata {
                 content_store,
                 &mut thread_rng(),
             )
-            .await
+            .await?;
+
+            let full_path: std::path::PathBuf = path_segments.iter().collect();
+            if let Some(mime) = mime_guess::MimeGuess::from_path(&full_path).first() {
+                file.content.metadata.put("mime_type", Ipld::String(mime.essence_str().to_string()));
+            }
+
+            file.content.metadata.put("size", Ipld::Integer(data_size as i128));
+
+            Ok(())
         } else {
             Err(SerialError::NodeNotFound(path_segments.join("/")).into())
         }

--- a/tomb-common/src/metadata.rs
+++ b/tomb-common/src/metadata.rs
@@ -545,10 +545,14 @@ impl FsMetadata {
 
             let full_path: std::path::PathBuf = path_segments.iter().collect();
             if let Some(mime) = mime_guess::MimeGuess::from_path(&full_path).first() {
-                file.content.metadata.put("mime_type", Ipld::String(mime.essence_str().to_string()));
+                file.content
+                    .metadata
+                    .put("mime_type", Ipld::String(mime.essence_str().to_string()));
             }
 
-            file.content.metadata.put("size", Ipld::Integer(data_size as i128));
+            file.content
+                .metadata
+                .put("size", Ipld::Integer(data_size as i128));
 
             Ok(())
         } else {

--- a/tomb-common/src/metadata.rs
+++ b/tomb-common/src/metadata.rs
@@ -544,7 +544,7 @@ impl FsMetadata {
             .await?;
 
             let full_path: std::path::PathBuf = path_segments.iter().collect();
-            if let Some(mime) = mime_guess::MimeGuess::from_path(&full_path).first() {
+            if let Some(mime) = mime_guess::MimeGuess::from_path(full_path).first() {
                 file.content
                     .metadata
                     .put("mime_type", Ipld::String(mime.essence_str().to_string()));

--- a/tomb-wasm/src/types.rs
+++ b/tomb-wasm/src/types.rs
@@ -52,19 +52,19 @@ impl TryFrom<WasmNodeMetadata> for JsValue {
     fn try_from(fs_entry: WasmNodeMetadata) -> Result<Self, Self::Error> {
         let object = Object::new();
 
-        if let Some(Ipld::Integer(i)) = fs_entry.0.0.get("created") {
+        if let Some(Ipld::Integer(i)) = fs_entry.0 .0.get("created") {
             Reflect::set(&object, &JsValue::from_str("created"), &value!(*i as f64))?;
         }
 
-        if let Some(Ipld::Integer(i)) = fs_entry.0.0.get("modified") {
+        if let Some(Ipld::Integer(i)) = fs_entry.0 .0.get("modified") {
             Reflect::set(&object, &JsValue::from_str("modified"), &value!(*i as f64))?;
         }
 
-        if let Some(Ipld::String(s)) = fs_entry.0.0.get("mime_type") {
+        if let Some(Ipld::String(s)) = fs_entry.0 .0.get("mime_type") {
             Reflect::set(&object, &JsValue::from_str("mime_type"), &value!(s))?;
         }
 
-        if let Some(Ipld::Integer(i)) = fs_entry.0.0.get("size") {
+        if let Some(Ipld::Integer(i)) = fs_entry.0 .0.get("size") {
             Reflect::set(&object, &JsValue::from_str("size"), &value!(*i as f64))?;
         }
 

--- a/tomb-wasm/src/types.rs
+++ b/tomb-wasm/src/types.rs
@@ -52,20 +52,22 @@ impl TryFrom<WasmNodeMetadata> for JsValue {
     fn try_from(fs_entry: WasmNodeMetadata) -> Result<Self, Self::Error> {
         let object = Object::new();
 
-        if let Some(Ipld::Integer(i)) = fs_entry.0 .0.get("created") {
+        if let Some(Ipld::Integer(i)) = fs_entry.0.0.get("created") {
             Reflect::set(&object, &JsValue::from_str("created"), &value!(*i as f64))?;
         }
 
-        if let Some(Ipld::Integer(i)) = fs_entry.0 .0.get("modified") {
+        if let Some(Ipld::Integer(i)) = fs_entry.0.0.get("modified") {
             Reflect::set(&object, &JsValue::from_str("modified"), &value!(*i as f64))?;
         }
 
-        // TODO: Remove stubs, with standard object
-        Reflect::set(
-            &object,
-            &JsValue::from_str("size"),
-            &JsValue::from_f64(1024.0),
-        )?;
+        if let Some(Ipld::String(s)) = fs_entry.0.0.get("mime_type") {
+            Reflect::set(&object, &JsValue::from_str("mime_type"), &value!(s))?;
+        }
+
+        if let Some(Ipld::Integer(i)) = fs_entry.0.0.get("size") {
+            Reflect::set(&object, &JsValue::from_str("size"), &value!(*i as f64))?;
+        }
+
         Reflect::set(
             &object,
             &JsValue::from_str("cid"),


### PR DESCRIPTION
Looks like mime_type still isn't being reported correctly but the wiring is at least there and this adds in the true file size.