### PR TITLE
fix: rm stray log

### DIFF
--- a/tomb-wasm/src/lib.rs
+++ b/tomb-wasm/src/lib.rs
@@ -72,8 +72,6 @@ impl TombWasm {
 
         log!("tomb-wasm: new()");
 
-        log!(format!("tomb-wasm pem: {}", signing_key_pem));
-
         let mut banyan_client = Client::new(&core_endpoint, &data_endpoint).unwrap();
         let signing_key = EcSignatureKey::import(signing_key_pem.as_bytes())
             .await


### PR DESCRIPTION
removes printing the pem to the terminal on new()