### PR TITLE
feat: rename buckets

### DIFF
--- a/src/api/models/bucket.rs
+++ b/src/api/models/bucket.rs
@@ -12,6 +12,7 @@ use crate::api::{
             delete::DeleteBucket,
             read::{ReadAllBuckets, ReadAllBucketsResponse, ReadBucket, ReadBucketResponse},
             snapshots::read::ReadAllSnapshots,
+            update::UpdateBucket,
             usage::GetBucketUsage,
         },
         staging::client_grant::authorization::AuthorizationGrants,
@@ -163,6 +164,13 @@ impl Bucket {
         })
     }
 
+    /// Update the bucket fields. Puts the current local values against the current remote values.
+    /// For now only updates to 'name' will be processed, all others will be ignored
+    pub async fn update(&self, client: &mut Client) -> Result<(), ClientError> {
+        let update_request = UpdateBucket(self.clone());
+        client.call_no_content(update_request).await
+    }
+
     /// Get the snapshots for the bucket
     pub async fn list_snapshots(&self, client: &mut Client) -> Result<Vec<Snapshot>, ClientError> {
         let response = client.call(ReadAllSnapshots { bucket_id: self.id }).await?;
@@ -297,6 +305,21 @@ pub mod test {
         assert!(read_bucket.is_err());
         let read_bucket = Bucket::read(&mut bad_client, fake_bucket().id).await;
         assert!(read_bucket.is_err());
+        Ok(())
+    }
+    #[tokio::test]
+    async fn create_update() -> Result<(), ClientError> {
+        let mut client = authenticated_client().await;
+        let (mut bucket, _) = create_bucket(&mut client).await?;
+        // TODO: test for other bucket updates when that is supported.
+        bucket.name = "new_name".to_string();
+        bucket.update(&mut client).await?;
+        let read_bucket = Bucket::read(&mut client, bucket.id).await?;
+        assert_eq!(read_bucket.name, bucket.name);
+        assert_eq!(read_bucket.name, "new_name");
+        assert_eq!(read_bucket.r#type, bucket.r#type);
+        assert_eq!(read_bucket.id, bucket.id);
+        assert_eq!(read_bucket.storage_class, bucket.storage_class);
         Ok(())
     }
     #[tokio::test]

--- a/src/api/requests/core/buckets/mod.rs
+++ b/src/api/requests/core/buckets/mod.rs
@@ -5,4 +5,5 @@ pub mod snapshots;
 pub mod create;
 pub mod delete;
 pub mod read;
+pub mod update;
 pub mod usage;

--- a/src/api/requests/core/buckets/update.rs
+++ b/src/api/requests/core/buckets/update.rs
@@ -1,0 +1,42 @@
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+
+use reqwest::{Client, RequestBuilder, Url};
+use serde::Deserialize;
+
+use crate::api::{models::bucket::Bucket, requests::ApiRequest};
+
+pub struct UpdateBucket(pub Bucket);
+
+#[derive(Deserialize)]
+pub struct UpdateBucketResponse;
+
+impl ApiRequest for UpdateBucket {
+    type ResponseType = UpdateBucketResponse;
+    type ErrorType = UpdateBucketError;
+
+    fn build_request(self, base_url: &Url, client: &Client) -> RequestBuilder {
+        let url = base_url
+            .join(&format!("/api/v1/buckets/{}", self.0.id))
+            .unwrap();
+        client.put(url).json(&self.0)
+    }
+
+    fn requires_authentication(&self) -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[non_exhaustive]
+pub struct UpdateBucketError {
+    msg: String,
+}
+
+impl Display for UpdateBucketError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.msg)
+    }
+}
+
+impl Error for UpdateBucketError {}

--- a/src/wasm/compat/mod.rs
+++ b/src/wasm/compat/mod.rs
@@ -285,6 +285,30 @@ impl TombWasm {
         Ok(WasmBucketKey(bucket_key))
     }
 
+    /// Rename a bucket
+    /// # Arguments
+    /// * `bucket_id` - The id of the bucket to rename
+    /// * `name` - the new name to give to the bucket
+    /// # Returns Promise<void> in js speak
+    #[wasm_bindgen(js_name = renameBucket)]
+    pub async fn rename_bucket(&mut self, bucket_id: String, name: String) -> TombResult<()> {
+        log!("tomb-wasm: rename_bucket()");
+
+        // Parse the bucket id
+        let bucket_id = Uuid::parse_str(&bucket_id).unwrap();
+
+        // We have to read here since the endpoint is expecting a PUT request
+        let mut bucket = Bucket::read(self.client(), bucket_id)
+            .await
+            .map_err(|err| TombWasmError(format!("failed to read renamed bucket: {err}")))?;
+
+        bucket.name = name;
+        bucket
+            .update(self.client())
+            .await
+            .map_err(|err| TombWasmError(format!("failed to rename bucket: {err}")).into())
+    }
+
     /// Delete a bucket
     /// # Arguments
     /// * `bucket_id` - The id of the bucket to delete

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -94,6 +94,21 @@ mod test {
         Ok(())
     }
 
+    #[wasm_bindgen_test]
+    async fn rename() -> TombResult<()> {
+        log!("tomb_wasm_test: create_bucket_mount_rename()");
+        let mut client = authenticated_client().await?;
+        let (_, initial_bucket_key_pem) = ecencryption_key_pair().await;
+        let bucket = create_bucket(&mut client, initial_bucket_key_pem).await?;
+        client
+            .rename_bucket(bucket.id().to_string(), "new_name".to_string())
+            .await?;
+        let buckets = client.list_buckets().await?;
+        let bucket = WasmBucket::try_from(buckets.get(0)).unwrap();
+        assert_eq!(bucket.name(), "new_name");
+        Ok(())
+    }
+
     // TODO: probably for API tests
     #[wasm_bindgen_test]
     async fn mount() -> TombResult<()> {
@@ -103,6 +118,22 @@ mod test {
         let bucket = create_bucket(&mut client, initial_bucket_key_pem).await?;
         let mount = client.mount(bucket.id().to_string(), private_pem).await?;
         assert!(!mount.locked());
+        Ok(())
+    }
+
+    #[wasm_bindgen_test]
+    async fn mount_rename() -> TombResult<()> {
+        log!("tomb_wasm_test: create_bucket_mount_rename()");
+        let mut client = authenticated_client().await?;
+        let (private_pem, initial_bucket_key_pem) = ecencryption_key_pair().await;
+        let bucket = create_bucket(&mut client, initial_bucket_key_pem).await?;
+        let mut mount = client
+            .mount(bucket.id().to_string(), private_pem.clone())
+            .await?;
+        mount.rename("new_name".to_string()).await?;
+        assert_eq!(mount.bucket().name(), "new_name");
+        let mount = client.mount(bucket.id().to_string(), private_pem).await?;
+        assert_eq!(mount.bucket().name(), "new_name");
         Ok(())
     }
 

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -96,7 +96,7 @@ mod test {
 
     #[wasm_bindgen_test]
     async fn rename() -> TombResult<()> {
-        log!("tomb_wasm_test: create_bucket_mount_rename()");
+        log!("tomb_wasm_test: create_bucket_rename()");
         let mut client = authenticated_client().await?;
         let (_, initial_bucket_key_pem) = ecencryption_key_pair().await;
         let bucket = create_bucket(&mut client, initial_bucket_key_pem).await?;


### PR DESCRIPTION
# Description
Implements API request for updating Bucket through a PUT request. Right now the core server only accepts updates to `name`

Implements methods and tests for two possible workflows for renaming a bucket in wasm module
- through the highest level api client
- through the mount client