### PR TITLE
Alex/cli fixes for storage provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,9 +769,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f85c3514d2a6e64160359b45a3918c3b4178bcbf4ae5d03ab2d02e521c479a"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -841,15 +841,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c904b33cc60130e1aeea4956ab803d08a3f4a0ca82d64ed757afac3891f2bb99"
+checksum = "20c01c06f5f429efdf2bae21eb67c28b3df3cf85b7dd2d8ef09c0838dac5d33e"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -857,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fdf3fce3ce863539ec1d7fd1b6dcc3c645663376b43ed376bbf887733e4f772"
+checksum = "0047d07f2c89b17dd631c80450d69841a6b5d7fb17278cbc43d7e4cfcf2576f3"
 dependencies = [
  "data-encoding",
  "syn 1.0.109",
@@ -945,15 +945,15 @@ checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.8"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der 0.7.8",
  "digest",
  "elliptic-curve",
  "rfc6979",
- "signature 2.1.0",
+ "signature 2.2.0",
  "spki 0.7.2",
 ]
 
@@ -975,9 +975,9 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.6"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97ca172ae9dc9f9b779a6e3a65d308f2af74e5b8c921299075bdb4a0370e914"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -1030,9 +1030,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
+checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -1943,16 +1943,16 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
+checksum = "3f01b677d82ef7a676aa37e099defd83a28e15687112cafdd112d60236b6115b"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
  "once_cell",
  "sha2",
- "signature 2.1.0",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -2698,9 +2698,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "primeorder"
-version = "0.13.3"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7dbe9ed3b56368bd99483eb32fe9c17fdd3730aebadc906918ce78d54c7eeb4"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
 ]
@@ -3086,9 +3086,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.33.0"
+version = "1.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076ba1058b036d3ca8bcafb1d54d0b0572e99d7ecd3e4222723e18ca8e9ca9a8"
+checksum = "06676aec5ccb8fc1da723cc8c0f9a46549f21ebb8753d3915c6c41db1e7f1dc4"
 dependencies = [
  "arrayvec",
  "num-traits",
@@ -3102,9 +3102,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.24"
+version = "0.38.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad981d6c340a49cdc40a1028d9c6084ec7e9fa33fcb839cab656a267071e234"
+checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -3203,9 +3203,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
@@ -3241,9 +3241,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3372,9 +3372,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core 0.6.4",
@@ -3741,11 +3741,12 @@ dependencies = [
 [[package]]
 name = "tomb-crypt"
 version = "0.1.0"
-source = "git+https://github.com/banyancomputer/tomb-crypt?branch=main#0cd64a2845cf6a612c34cb1573386e030f5fda4c"
+source = "git+https://github.com/banyancomputer/tomb-crypt?branch=main#cdd5e07de53b2a2cde830bb56e453f3c5632d2d7"
 dependencies = [
  "aes-gcm",
  "async-trait",
  "base64ct",
+ "blake3",
  "chrono",
  "console_error_panic_hook",
  "getrandom",
@@ -3755,7 +3756,6 @@ dependencies = [
  "rand 0.8.5",
  "rand_core 0.6.4",
  "serde",
- "sha1",
  "sha2",
  "tokio",
 ]
@@ -3952,9 +3952,9 @@ dependencies = [
 
 [[package]]
 name = "utf8-width"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
+checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
 name = "utf8parse"
@@ -3964,9 +3964,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
+checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom",
  "serde",
@@ -4323,7 +4323,7 @@ dependencies = [
 [[package]]
 name = "wnfs"
 version = "0.1.21"
-source = "git+https://github.com/banyancomputer/rs-wnfs?branch=main#55858a9ae7ae2f520a96b99a4b005184305aa944"
+source = "git+https://github.com/banyancomputer/rs-wnfs?branch=main#169e7d7a7ccfe0b4fd2af520b106d19c4b003ee1"
 dependencies = [
  "aes-gcm",
  "aes-kw",
@@ -4353,7 +4353,7 @@ dependencies = [
 [[package]]
 name = "wnfs-common"
 version = "0.1.21"
-source = "git+https://github.com/banyancomputer/rs-wnfs?branch=main#55858a9ae7ae2f520a96b99a4b005184305aa944"
+source = "git+https://github.com/banyancomputer/rs-wnfs?branch=main#169e7d7a7ccfe0b4fd2af520b106d19c4b003ee1"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -4371,7 +4371,7 @@ dependencies = [
 [[package]]
 name = "wnfs-hamt"
 version = "0.1.21"
-source = "git+https://github.com/banyancomputer/rs-wnfs?branch=main#55858a9ae7ae2f520a96b99a4b005184305aa944"
+source = "git+https://github.com/banyancomputer/rs-wnfs?branch=main#169e7d7a7ccfe0b4fd2af520b106d19c4b003ee1"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "wnfs-namefilter"
 version = "0.1.21"
-source = "git+https://github.com/banyancomputer/rs-wnfs?branch=main#55858a9ae7ae2f520a96b99a4b005184305aa944"
+source = "git+https://github.com/banyancomputer/rs-wnfs?branch=main#169e7d7a7ccfe0b4fd2af520b106d19c4b003ee1"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -4439,6 +4439,6 @@ checksum = "9828b178da53440fa9c766a3d2f73f7cf5d0ac1fe3980c1e5018d899fd19e07b"
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/src/api/models/metadata.rs
+++ b/src/api/models/metadata.rs
@@ -327,6 +327,7 @@ pub(crate) mod test {
         })
     }
 
+    // TODO: this test fails if not serial. This should be fixed
     #[tokio::test]
     #[serial]
     async fn push_read_pull() -> Result<(), ApiError> {

--- a/src/api/requests/core/blocks/locate.rs
+++ b/src/api/requests/core/blocks/locate.rs
@@ -52,6 +52,7 @@ impl Error for LocationRequestError {}
 #[cfg(feature = "integration-tests")]
 mod test {
     use std::collections::BTreeSet;
+    use wnfs::libipld::Cid;
 
     use crate::{
         api::{
@@ -66,11 +67,9 @@ mod test {
         blockstore::{BanyanApiBlockStore, DoubleSplitStore},
         filesystem::FilesystemError,
     };
-    use serial_test::serial;
-    use wnfs::libipld::Cid;
 
     #[tokio::test]
-    #[serial]
+
     async fn get_locations() -> Result<(), ApiError> {
         let mut setup = setup_and_push_metadata("get_locations").await?;
         // Create a grant and upload content
@@ -123,7 +122,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[serial]
+
     async fn get_bad_location() -> Result<(), ApiError> {
         let mut client = authenticated_client().await;
         let mut cids = BTreeSet::new();

--- a/src/api/requests/core/blocks/locate.rs
+++ b/src/api/requests/core/blocks/locate.rs
@@ -88,10 +88,10 @@ mod test {
             )
             .await?;
 
-        let mut blockstore_client = setup.client.clone();
-        blockstore_client
-            .with_remote(&setup.storage_ticket.host)
-            .expect("Failed to create blockstore client");
+        // Wait for the content to be uploaded
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+        let blockstore_client = setup.client.clone();
         let api_blockstore = BanyanApiBlockStore::from(blockstore_client);
         let node = setup
             .fs

--- a/src/api/requests/staging/client_grant/mod.rs
+++ b/src/api/requests/staging/client_grant/mod.rs
@@ -6,15 +6,13 @@ pub mod create;
 #[cfg(test)]
 #[cfg(feature = "integration-tests")]
 mod test {
-    use serial_test::serial;
-
     use crate::api::{
         error::ApiError, models::metadata::test::setup_and_push_metadata,
         requests::staging::upload::content::UploadContent,
     };
 
     #[tokio::test]
-    #[serial]
+
     async fn create_grant() -> Result<(), ApiError> {
         let mut setup = setup_and_push_metadata("create_grant").await?;
         setup.storage_ticket.create_grant(&mut setup.client).await?;
@@ -22,7 +20,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[serial]
+
     async fn authorization_grants() -> Result<(), ApiError> {
         let mut setup = setup_and_push_metadata("authorization_grants").await?;
         // Create a grant
@@ -42,6 +40,10 @@ mod test {
                 &mut setup.client,
             )
             .await?;
+
+        // Sleep to allow upload report to be processed
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
         // Successfully get a new bearer token which can access the new grants
         setup.bucket.get_grants_token(&mut setup.client).await?;
         Ok(())

--- a/src/api/requests/staging/pull_blocks.rs
+++ b/src/api/requests/staging/pull_blocks.rs
@@ -81,6 +81,9 @@ mod test {
             )
             .await?;
 
+        // Sleep to allow block locations to be updated
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        
         let mut cids = <BTreeSet<Cid>>::new();
         for bucket in setup.content_store.car.car.index.borrow().clone().buckets {
             cids.extend(bucket.map.into_keys().collect::<BTreeSet<Cid>>());
@@ -88,6 +91,7 @@ mod test {
 
         let api_store = BanyanApiBlockStore::from(setup.client);
         api_store.find_cids(cids.clone()).await?;
+
 
         for cid in &cids {
             assert!(api_store.get_block(cid).await.is_ok());

--- a/src/api/requests/staging/pull_blocks.rs
+++ b/src/api/requests/staging/pull_blocks.rs
@@ -58,12 +58,11 @@ mod test {
         },
         blockstore::BanyanApiBlockStore,
     };
-    use serial_test::serial;
     use wnfs::common::BlockStore;
     use wnfs::libipld::Cid;
 
     #[tokio::test]
-    #[serial]
+
     async fn download_content() -> Result<(), ApiError> {
         let mut setup = setup_and_push_metadata("download_content").await?;
         // Create a grant and upload content
@@ -83,7 +82,7 @@ mod test {
 
         // Sleep to allow block locations to be updated
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-        
+
         let mut cids = <BTreeSet<Cid>>::new();
         for bucket in setup.content_store.car.car.index.borrow().clone().buckets {
             cids.extend(bucket.map.into_keys().collect::<BTreeSet<Cid>>());
@@ -91,7 +90,6 @@ mod test {
 
         let api_store = BanyanApiBlockStore::from(setup.client);
         api_store.find_cids(cids.clone()).await?;
-
 
         for cid in &cids {
             assert!(api_store.get_block(cid).await.is_ok());

--- a/src/api/requests/staging/upload/content.rs
+++ b/src/api/requests/staging/upload/content.rs
@@ -72,10 +72,9 @@ mod test {
         error::ApiError, models::metadata::test::setup_and_push_metadata,
         requests::staging::upload::content::UploadContent,
     };
-    use serial_test::serial;
 
     #[tokio::test]
-    #[serial]
+
     async fn upload_content() -> Result<(), ApiError> {
         let mut setup = setup_and_push_metadata("upload_content").await?;
         // Create a grant and upload content

--- a/src/blockstore/api.rs
+++ b/src/blockstore/api.rs
@@ -63,7 +63,8 @@ impl BanyanBlockStore for BanyanApiBlockStore {
         let mut maybe_url = None;
         for (url, cids) in self.block_locations.borrow().iter() {
             if cids.contains(&cid.to_string()) {
-                let base_url = Url::parse(url).map_err(|_| BlockStoreError::wnfs(Box::from("url parse")))?;
+                let base_url =
+                    Url::parse(url).map_err(|_| BlockStoreError::wnfs(Box::from("url parse")))?;
                 maybe_url = Some(base_url);
                 break;
             }

--- a/src/native/sync/mod.rs
+++ b/src/native/sync/mod.rs
@@ -276,11 +276,7 @@ pub async fn sync_bucket(
                 .map(|ticket| ticket.host)
                 .unwrap_or(global.endpoints.data.clone());
 
-            let mut api_blockstore_client = client.clone();
-            api_blockstore_client
-                .with_remote(&storage_host)
-                .expect("could not create blockstore client");
-
+            let api_blockstore_client = client.clone();
             let api_blockstore = BanyanApiBlockStore::from(api_blockstore_client);
             // If getting a block is an error
             if api_blockstore

--- a/src/wasm/compat/mount.rs
+++ b/src/wasm/compat/mount.rs
@@ -637,10 +637,7 @@ impl WasmMount {
             panic!("Bucket is locked");
         };
 
-        let mut api_blockstore_client = self.client.clone();
-        api_blockstore_client
-            .with_remote(self.client.remote_data.as_str())
-            .expect("could not create blockstore client");
+        let api_blockstore_client = self.client.clone();
         let api_blockstore = BanyanApiBlockStore::from(api_blockstore_client);
 
         let fs = self.fs_metadata.as_mut().unwrap();


### PR DESCRIPTION
# Description
Fixes multi storage provider bugs
Updates integration tests that rely on cascading updates (ie block locations on upload to a provider) to wait 1s before calling time sensitive code
Brings in updated tomb-crypto dep for new fingerprinting