### PR TITLE
Vera/ENG-440 Remove .unwraps and .expects from WASM calls

### DIFF
--- a/src/filesystem/error.rs
+++ b/src/filesystem/error.rs
@@ -32,6 +32,8 @@ impl Display for FilesystemError {
     }
 }
 
+impl std::error::Error for FilesystemError {}
+
 impl FilesystemError {
     pub fn node_not_found(path: &str) -> Self {
         Self {

--- a/src/filesystem/sharing/error.rs
+++ b/src/filesystem/sharing/error.rs
@@ -34,6 +34,8 @@ impl SharingError {
     }
 }
 
+impl std::error::Error for SharingError {}
+
 impl Display for SharingError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let string = match &self.kind {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,8 @@ pub mod prelude {
     #[cfg(target_arch = "wasm32")]
     pub mod wasm {
         pub use crate::wasm::{
-            to_wasm_error, TombResult, TombWasm, TombWasmError, WasmBucket, WasmBucketKey,
-            WasmBucketMetadata, WasmFsMetadataEntry, WasmMount, WasmNodeMetadata, WasmSnapshot,
+            TombResult, TombWasm, TombWasmError, WasmBucket, WasmBucketKey, WasmBucketMetadata,
+            WasmFsMetadataEntry, WasmMount, WasmNodeMetadata, WasmSnapshot,
         };
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,8 @@ pub mod prelude {
     #[cfg(target_arch = "wasm32")]
     pub mod wasm {
         pub use crate::wasm::{
-            TombResult, TombWasm, TombWasmError, WasmBucket, WasmBucketKey, WasmBucketMetadata,
-            WasmFsMetadataEntry, WasmMount, WasmNodeMetadata, WasmSnapshot,
+            to_wasm_error, TombResult, TombWasm, TombWasmError, WasmBucket, WasmBucketKey,
+            WasmBucketMetadata, WasmFsMetadataEntry, WasmMount, WasmNodeMetadata, WasmSnapshot,
         };
     }
 }

--- a/src/wasm/compat/mod.rs
+++ b/src/wasm/compat/mod.rs
@@ -5,9 +5,8 @@ mod types;
 
 pub use mount::WasmMount;
 pub use types::{
-    to_js_error_with_debug, to_wasm_error, to_wasm_error_with_debug, TombWasmError, WasmBucket,
-    WasmBucketKey, WasmBucketMetadata, WasmFsMetadataEntry, WasmNodeMetadata, WasmSharedFile,
-    WasmSnapshot,
+    to_js_error_with_debug, to_wasm_error_with_debug, TombWasmError, WasmBucket, WasmBucketKey,
+    WasmBucketMetadata, WasmFsMetadataEntry, WasmNodeMetadata, WasmSharedFile, WasmSnapshot,
 };
 
 use crate::api::{
@@ -235,10 +234,12 @@ impl TombWasm {
         initial_bucket_key_pem: String,
     ) -> TombResult<WasmBucket> {
         log!("tomb-wasm: create_bucket()");
-        let storage_class = StorageClass::from_str(&storage_class)
-            .map_err(|err| to_wasm_error_with_debug("invalid storage class")(TombWasmError(err)))?;
-        let bucket_type = BucketType::from_str(&bucket_type)
-            .map_err(|err| to_wasm_error_with_debug("invalid drive type")(TombWasmError(err)))?;
+        let storage_class = StorageClass::from_str(&storage_class).map_err(|err| {
+            to_wasm_error_with_debug("invalid storage class")(TombWasmError::new(&err))
+        })?;
+        let bucket_type = BucketType::from_str(&bucket_type).map_err(|err| {
+            to_wasm_error_with_debug("invalid drive type")(TombWasmError::new(&err))
+        })?;
         // Call the API
         let (bucket, _bucket_key) = Bucket::create(
             name,

--- a/src/wasm/compat/mod.rs
+++ b/src/wasm/compat/mod.rs
@@ -233,8 +233,10 @@ impl TombWasm {
         initial_bucket_key_pem: String,
     ) -> TombResult<WasmBucket> {
         log!("tomb-wasm: create_bucket()");
-        let storage_class = StorageClass::from_str(&storage_class).expect("Invalid storage class");
-        let bucket_type = BucketType::from_str(&bucket_type).expect("Invalid bucket type");
+        let storage_class = StorageClass::from_str(&storage_class)
+            .map_err(|err| to_js_error_with_debug("invalid storage class")(TombWasmError(err)))?;
+        let bucket_type = BucketType::from_str(&bucket_type)
+            .map_err(|err| to_js_error_with_debug("invalid drive type")(TombWasmError(err)))?;
         // Call the API
         let (bucket, _bucket_key) = Bucket::create(
             name,
@@ -244,7 +246,7 @@ impl TombWasm {
             self.client(),
         )
         .await
-        .expect("Failed to create bucket");
+        .map_err(to_js_error_with_debug("create bucket"))?;
         // Convert the bucket
         let wasm_bucket = WasmBucket::from(bucket);
         // Ok

--- a/src/wasm/compat/mount.rs
+++ b/src/wasm/compat/mount.rs
@@ -367,7 +367,7 @@ impl WasmMount {
             self.bucket.id,
         ));
         let Some(metadata_cid) = self.metadata_blockstore.get_root() else {
-            return Err(TombWasmError("unable to retrieve metadata CID".to_string()));
+            return Err(TombWasmError::new("unable to retrieve metadata CID"));
         };
         // Default to the metadata cid if its not present
         // Remember this is the CID of the IPLD, which will be the same in both cases.
@@ -466,10 +466,9 @@ impl WasmMount {
         );
 
         if self.locked() {
-            return Err(TombWasmError(
-                "unable to list directory contents of a locked bucket".to_string(),
-            )
-            .into());
+            return Err(
+                TombWasmError::new("unable to list directory contents of a locked bucket").into(),
+            );
         };
 
         log!(format!(
@@ -498,7 +497,7 @@ impl WasmMount {
             .map(|entry| {
                 let wasm_fs_metadata_entry = WasmFsMetadataEntry::from(entry.clone());
                 JsValue::try_from(wasm_fs_metadata_entry).map_err(|err| {
-                    TombWasmError(format!(
+                    TombWasmError::new(&format!(
                         "unable to convert directory entries to JS objects: {err:?}"
                     ))
                     .into()
@@ -873,9 +872,7 @@ impl WasmMount {
             .collect::<Vec<String>>();
 
         if self.locked() {
-            return Err(
-                TombWasmError("unable to share a file from a locked bucket".to_string()).into(),
-            );
+            return Err(TombWasmError::new("unable to share a file from a locked bucket").into());
         };
 
         let shared_file = self
@@ -932,9 +929,10 @@ impl WasmMount {
     #[wasm_bindgen(js_name = snapshot)]
     pub async fn snapshot(&mut self) -> TombResult<String> {
         log!("tomb-wasm: mount/snapshot/{}", self.bucket.id.to_string());
-        let metadata = self.metadata.as_mut().ok_or_else(|| {
-            TombWasmError("no metadata associated with mount to snapshot".to_string())
-        })?;
+        let metadata = self
+            .metadata
+            .as_mut()
+            .ok_or_else(|| TombWasmError::new("no metadata associated with mount to snapshot"))?;
 
         let snapshot_id = metadata
             .snapshot(&mut self.client)

--- a/src/wasm/compat/mount.rs
+++ b/src/wasm/compat/mount.rs
@@ -26,8 +26,6 @@ use crate::{
     },
 };
 
-use super::to_js_error_with_debug;
-
 /// Mount point for a Bucket in WASM
 ///
 /// Enables to call Fs methods on a Bucket, pulling metadata from a remote
@@ -648,12 +646,15 @@ impl WasmMount {
         let api_blockstore_client = self.client.clone();
         let api_blockstore = BanyanApiBlockStore::from(api_blockstore_client);
 
-        let fs = self.fs_metadata.as_mut().ok_or(TombWasmError::new("missing FsMetadata"))?;
+        let fs = self
+            .fs_metadata
+            .as_mut()
+            .ok_or(TombWasmError::new("missing FsMetadata"))?;
 
         let node = fs
             .get_node(&path_segments, &self.metadata_blockstore)
             .await
-            .map_err(to_js_error_with_debug("access FsMetadata"))?
+            .map_err(to_wasm_error_with_debug("access FsMetadata"))?
             .ok_or(TombWasmError::new("no node at path"))?;
 
         if let PrivateNode::File(file) = node {
@@ -765,7 +766,10 @@ impl WasmMount {
             panic!("Bucket is locked");
         };
 
-        let fs = self.fs_metadata.as_mut().ok_or(TombWasmError::new("missing FsMetadata"))?;
+        let fs = self
+            .fs_metadata
+            .as_mut()
+            .ok_or(TombWasmError::new("missing FsMetadata"))?;
 
         let node = fs
             .get_node(&path_segments, &self.metadata_blockstore)

--- a/src/wasm/compat/mount.rs
+++ b/src/wasm/compat/mount.rs
@@ -130,7 +130,7 @@ impl WasmMount {
         );
         let mut data = Vec::new();
         while let Some(chunk) = stream.next().await {
-            data.extend_from_slice(&chunk.unwrap());
+            data.extend_from_slice(&chunk.map_err(to_wasm_error_with_debug("chunk from stream"))?);
         }
         log!(
             "tomb-wasm: mount/pull()/{} - creating metadata blockstore",
@@ -188,7 +188,7 @@ impl WasmMount {
 
         let mut data = Vec::new();
         while let Some(chunk) = stream.next().await {
-            data.extend_from_slice(&chunk.unwrap());
+            data.extend_from_slice(&chunk.map_err(to_wasm_error_with_debug("chunk from stream"))?);
         }
 
         log!(
@@ -542,7 +542,7 @@ impl WasmMount {
         );
         self.fs_metadata
             .as_mut()
-            .unwrap()
+            .ok_or(TombWasmError::new("missing FsMetadata"))?
             .mkdir(&path_segments, &self.metadata_blockstore)
             .await
             .map_err(to_wasm_error_with_debug("mkdir"))?;
@@ -593,7 +593,7 @@ impl WasmMount {
 
         self.fs_metadata
             .as_mut()
-            .unwrap()
+            .ok_or(TombWasmError::new("missing FsMetadata"))?
             .write(
                 &path_segments,
                 &self.metadata_blockstore,
@@ -648,7 +648,7 @@ impl WasmMount {
         let api_blockstore_client = self.client.clone();
         let api_blockstore = BanyanApiBlockStore::from(api_blockstore_client);
 
-        let fs = self.fs_metadata.as_mut().unwrap();
+        let fs = self.fs_metadata.as_mut().ok_or(TombWasmError::new("missing FsMetadata"))?;
 
         let node = fs
             .get_node(&path_segments, &self.metadata_blockstore)
@@ -719,7 +719,7 @@ impl WasmMount {
 
         self.fs_metadata
             .as_mut()
-            .unwrap()
+            .ok_or(TombWasmError::new("missing FsMetadata"))?
             .mv(
                 &from_path_segments,
                 &to_path_segments,
@@ -765,7 +765,7 @@ impl WasmMount {
             panic!("Bucket is locked");
         };
 
-        let fs = self.fs_metadata.as_mut().unwrap();
+        let fs = self.fs_metadata.as_mut().ok_or(TombWasmError::new("missing FsMetadata"))?;
 
         let node = fs
             .get_node(&path_segments, &self.metadata_blockstore)
@@ -840,7 +840,7 @@ impl WasmMount {
 
         self.fs_metadata
             .as_mut()
-            .unwrap()
+            .ok_or(TombWasmError::new("missing FsMetadata"))?
             .share_with(&recipient_key, &self.metadata_blockstore)
             .await
             .map_err(to_wasm_error_with_debug("fs share_with"))?;
@@ -877,7 +877,7 @@ impl WasmMount {
         let shared_file = self
             .fs_metadata
             .as_mut()
-            .unwrap()
+            .ok_or(TombWasmError::new("missing FsMetadata"))?
             .share_file(
                 &path_segments,
                 &self.metadata_blockstore,

--- a/src/wasm/compat/mount.rs
+++ b/src/wasm/compat/mount.rs
@@ -456,8 +456,8 @@ impl WasmMount {
         // Read the array as a Vec<String>
         let path_segments = path_segments
             .iter()
-            .map(|s| s.as_string().unwrap())
-            .collect::<Vec<String>>();
+            .map(|s| s.as_string().ok_or(TombWasmError::new("JsValue as string")))
+            .collect::<Result<Vec<String>, TombWasmError>>()?;
 
         log!(
             "tomb-wasm: mount/ls/{}/{}",
@@ -519,8 +519,8 @@ impl WasmMount {
         // Read the array as a Vec<String>
         let path_segments = path_segments
             .iter()
-            .map(|s| s.as_string().unwrap())
-            .collect::<Vec<String>>();
+            .map(|s| s.as_string().ok_or(TombWasmError::new("JsValue as string")))
+            .collect::<Result<Vec<String>, TombWasmError>>()?;
 
         log!(
             "tomb-wasm: mount/mkdir/{}/{}",
@@ -573,8 +573,8 @@ impl WasmMount {
         // Read the array as a Vec<String>
         let path_segments = path_segments
             .iter()
-            .map(|s| s.as_string().unwrap())
-            .collect::<Vec<String>>();
+            .map(|s| s.as_string().ok_or(TombWasmError::new("JsValue as string")))
+            .collect::<Result<Vec<String>, TombWasmError>>()?;
 
         log!(
             "tomb-wasm: mount/add/{}/{}",
@@ -629,8 +629,8 @@ impl WasmMount {
         // Read the array as a Vec<String>
         let path_segments = path_segments
             .iter()
-            .map(|s| s.as_string().unwrap())
-            .collect::<Vec<String>>();
+            .map(|s| s.as_string().ok_or(TombWasmError::new("JsValue as string")))
+            .collect::<Result<Vec<String>, TombWasmError>>()?;
 
         log!(
             "tomb-wasm: mount/read_bytes/{}/{}",
@@ -699,12 +699,12 @@ impl WasmMount {
     ) -> TombResult<()> {
         let from_path_segments = from_path_segments
             .iter()
-            .map(|s| s.as_string().unwrap())
-            .collect::<Vec<String>>();
+            .map(|s| s.as_string().ok_or(TombWasmError::new("JsValue as string")))
+            .collect::<Result<Vec<String>, TombWasmError>>()?;
         let to_path_segments = to_path_segments
             .iter()
-            .map(|s| s.as_string().unwrap())
-            .collect::<Vec<String>>();
+            .map(|s| s.as_string().ok_or(TombWasmError::new("JsValue as string")))
+            .collect::<Result<Vec<String>, TombWasmError>>()?;
 
         log!(
             "tomb-wasm: mount/mv/{}/{} => {}",
@@ -752,8 +752,8 @@ impl WasmMount {
     pub async fn rm(&mut self, path_segments: Array) -> TombResult<()> {
         let path_segments = path_segments
             .iter()
-            .map(|s| s.as_string().unwrap())
-            .collect::<Vec<String>>();
+            .map(|s| s.as_string().ok_or(TombWasmError::new("JsValue as string")))
+            .collect::<Result<Vec<String>, TombWasmError>>()?;
 
         log!(
             "tomb-wasm: mount/rm/{}/{}",
@@ -868,8 +868,8 @@ impl WasmMount {
         // Read the array as a Vec<String>
         let path_segments = path_segments
             .iter()
-            .map(|s| s.as_string().unwrap())
-            .collect::<Vec<String>>();
+            .map(|s| s.as_string().ok_or(TombWasmError::new("JsValue as string")))
+            .collect::<Result<Vec<String>, TombWasmError>>()?;
 
         if self.locked() {
             return Err(TombWasmError::new("unable to share a file from a locked bucket").into());

--- a/src/wasm/compat/mount.rs
+++ b/src/wasm/compat/mount.rs
@@ -1,4 +1,3 @@
-use crate::wasm::WasmBucketMetadata;
 use futures_util::StreamExt;
 use gloo::console::log;
 use js_sys::{Array, ArrayBuffer, Uint8Array};
@@ -21,7 +20,7 @@ use crate::{
     blockstore::{BanyanApiBlockStore, CarV2MemoryBlockStore as BlockStore, RootedBlockStore},
     filesystem::FsMetadata,
     wasm::{
-        compat::to_wasm_error_with_debug, TombResult, TombWasmError, WasmBucket,
+        to_wasm_error_with_debug, TombResult, TombWasmError, WasmBucket, WasmBucketMetadata,
         WasmFsMetadataEntry, WasmSharedFile, WasmSnapshot,
     },
 };

--- a/src/wasm/compat/mount.rs
+++ b/src/wasm/compat/mount.rs
@@ -239,7 +239,7 @@ impl WasmMount {
             let _ = self
                 .fs_metadata
                 .as_mut()
-                .unwrap()
+                .ok_or(TombWasmError::new("missing FsMetadata"))?
                 .save(&self.metadata_blockstore, &self.content_blockstore)
                 .await;
         } else {
@@ -373,7 +373,10 @@ impl WasmMount {
         // TODO change this if we stop using the same CIDs in both.
         let root_cid = self.content_blockstore.get_root().unwrap_or(metadata_cid);
 
-        let metadata = self.metadata.as_ref().unwrap();
+        let metadata = self
+            .metadata
+            .as_ref()
+            .ok_or(TombWasmError::new("missing FsMetadata"))?;
 
         assert_eq!(metadata_cid.to_string(), metadata.metadata_cid);
         assert_eq!(root_cid.to_string(), metadata.root_cid);
@@ -418,7 +421,7 @@ impl WasmMount {
         let metadata = self
             .metadata
             .as_ref()
-            .ok_or(TombWasmError::new("no metadata"))?;
+            .ok_or(TombWasmError::new("missing FsMetadata"))?;
         let wasm_bucket_metadata = WasmBucketMetadata(metadata.clone());
         Ok(wasm_bucket_metadata)
     }
@@ -480,7 +483,7 @@ impl WasmMount {
         let fs_metadata_entries = self
             .fs_metadata
             .as_ref()
-            .unwrap()
+            .ok_or(TombWasmError::new("missing FsMetadata"))?
             .ls(&path_segments, &self.metadata_blockstore)
             .await
             .map_err(to_wasm_error_with_debug("list directory entries"))?;
@@ -914,8 +917,9 @@ impl WasmMount {
         let metadata = self
             .metadata
             .as_ref()
-            .ok_or(TombWasmError::new("missing metadata"))
+            .ok_or(TombWasmError::new("missing FsMetadata"))
             .unwrap();
+
         metadata.snapshot_id.is_some()
     }
 

--- a/src/wasm/compat/types/bucket_metadata.rs
+++ b/src/wasm/compat/types/bucket_metadata.rs
@@ -1,4 +1,4 @@
-use crate::api::models::metadata::Metadata;
+use crate::{api::models::metadata::Metadata, wasm::TombWasmError};
 use wasm_bindgen::prelude::wasm_bindgen;
 
 #[wasm_bindgen]
@@ -18,6 +18,10 @@ impl WasmBucketMetadata {
 
     #[wasm_bindgen(getter = snapshotId)]
     pub fn snapshot_id(&self) -> String {
-        self.0.snapshot_id.expect("no snapshot").to_string()
+        self.0
+            .snapshot_id
+            .ok_or(TombWasmError::new("missing Snapshot id"))
+            .unwrap()
+            .to_string()
     }
 }

--- a/src/wasm/compat/types/error.rs
+++ b/src/wasm/compat/types/error.rs
@@ -25,10 +25,10 @@ impl From<TombWasmError> for js_sys::Error {
 
 impl Error for TombWasmError {}
 
-pub fn to_js_error_with_debug<E: Error>(message: &str) -> impl Fn(E) -> js_sys::Error + '_ {
+pub fn to_js_error_with_msg<E: Error>(message: &str) -> impl Fn(E) -> js_sys::Error + '_ {
     move |err| js_sys::Error::from(TombWasmError(format!("{} | {}", message, err)))
 }
 
-pub fn to_wasm_error_with_debug<E: Error>(message: &str) -> impl Fn(E) -> TombWasmError + '_ {
+pub fn to_wasm_error_with_msg<E: Error>(message: &str) -> impl Fn(E) -> TombWasmError + '_ {
     move |err| TombWasmError(format!("{} | {}", message, err))
 }

--- a/src/wasm/compat/types/error.rs
+++ b/src/wasm/compat/types/error.rs
@@ -5,6 +5,12 @@ use wasm_bindgen::JsValue;
 #[derive(Debug)]
 pub struct TombWasmError(pub(crate) String);
 
+impl TombWasmError {
+    pub fn new(message: &str) -> TombWasmError {
+        TombWasmError(String::from(message))
+    }
+}
+
 impl Display for TombWasmError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "tomm-wasm (unexpected error): {}", self.0)

--- a/src/wasm/compat/types/error.rs
+++ b/src/wasm/compat/types/error.rs
@@ -25,12 +25,6 @@ impl From<TombWasmError> for js_sys::Error {
 
 impl Error for TombWasmError {}
 
-impl From<Box<dyn Error>> for TombWasmError {
-    fn from(err: Box<dyn Error>) -> Self {
-        TombWasmError(format!("{}", err))
-    }
-}
-
 pub fn to_js_error_with_debug<E: Error>(message: &str) -> impl Fn(E) -> js_sys::Error + '_ {
     move |err| js_sys::Error::from(TombWasmError(format!("{} | {}", message, err)))
 }

--- a/src/wasm/compat/types/error.rs
+++ b/src/wasm/compat/types/error.rs
@@ -18,3 +18,21 @@ impl From<TombWasmError> for js_sys::Error {
 }
 
 impl Error for TombWasmError {}
+
+impl From<Box<dyn Error>> for TombWasmError {
+    fn from(err: Box<dyn Error>) -> Self {
+        TombWasmError(format!("{}", err))
+    }
+}
+
+pub fn to_wasm_error(err: impl Error) -> js_sys::Error {
+    TombWasmError(format!("{}", err)).into()
+}
+
+pub fn to_js_error_with_debug<E: Error>(message: &str) -> impl Fn(E) -> js_sys::Error + '_ {
+    move |err| js_sys::Error::from(TombWasmError(format!("{} | {}", message, err)))
+}
+
+pub fn to_wasm_error_with_debug<E: Error>(message: &str) -> impl Fn(E) -> TombWasmError + '_ {
+    move |err| TombWasmError(format!("{} | {}", message, err))
+}

--- a/src/wasm/compat/types/error.rs
+++ b/src/wasm/compat/types/error.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Display, Formatter};
 use wasm_bindgen::JsValue;
 
 #[derive(Debug)]
-pub struct TombWasmError(pub(crate) String);
+pub struct TombWasmError(String);
 
 impl TombWasmError {
     pub fn new(message: &str) -> TombWasmError {
@@ -29,10 +29,6 @@ impl From<Box<dyn Error>> for TombWasmError {
     fn from(err: Box<dyn Error>) -> Self {
         TombWasmError(format!("{}", err))
     }
-}
-
-pub fn to_wasm_error(err: impl Error) -> js_sys::Error {
-    TombWasmError(format!("{}", err)).into()
 }
 
 pub fn to_js_error_with_debug<E: Error>(message: &str) -> impl Fn(E) -> js_sys::Error + '_ {

--- a/src/wasm/compat/types/fs_metadata_entry.rs
+++ b/src/wasm/compat/types/fs_metadata_entry.rs
@@ -57,19 +57,21 @@ impl TryFrom<WasmFsMetadataEntry> for JsValue {
             &JsValue::from_str("name"),
             &JsValue::from_str(&name),
         )
-        .expect("we know this is an object");
+        .map_err(|_| TombWasmError::new("name property on object"))?;
+
         Reflect::set(
             &object,
             &JsValue::from_str("type"),
             &JsValue::from_str(entry_type),
         )
-        .expect("we know this is an object");
+        .map_err(|_| TombWasmError::new("type property on object"))?;
+
         Reflect::set(
             &object,
             &JsValue::from_str("metadata"),
             &JsValue::try_from(metadata)?,
         )
-        .expect("we know this is an object");
+        .map_err(|_| TombWasmError::new("metadata property on object"))?;
 
         Ok(value!(object))
     }
@@ -86,12 +88,12 @@ impl TryFrom<JsValue> for WasmFsMetadataEntry {
         })?;
 
         let name = Reflect::get(&object, &value!("name"))
-            .expect("we know this is an object")
+            .map_err(|_| TombWasmError::new("name property on object"))?
             .as_string()
             .ok_or(TombWasmError::new("name was not a string"))?;
 
         let type_str = Reflect::get(&object, &JsValue::from_str("type"))
-            .expect("we know this is an object")
+            .map_err(|_| TombWasmError::new("type property on object"))?
             .as_string()
             .ok_or(TombWasmError::new("type was not a string"))?;
 
@@ -106,7 +108,7 @@ impl TryFrom<JsValue> for WasmFsMetadataEntry {
         };
 
         let metadata_obj = Reflect::get(&object, &JsValue::from_str("metadata"))
-            .expect("we know this is an object");
+            .map_err(|_| TombWasmError::new("metadata property on object"))?;
 
         let metadata: WasmNodeMetadata = metadata_obj.try_into().map_err(|err| {
             TombWasmError::new(&format!(

--- a/src/wasm/compat/types/mod.rs
+++ b/src/wasm/compat/types/mod.rs
@@ -10,7 +10,7 @@ mod snapshot;
 pub use bucket::WasmBucket;
 pub use bucket_key::WasmBucketKey;
 pub use bucket_metadata::WasmBucketMetadata;
-pub use error::{to_js_error_with_debug, to_wasm_error, to_wasm_error_with_debug, TombWasmError};
+pub use error::{to_js_error_with_debug, to_wasm_error_with_debug, TombWasmError};
 pub use fs_metadata_entry::WasmFsMetadataEntry;
 pub use node_metadata::WasmNodeMetadata;
 pub use shared_file::WasmSharedFile;

--- a/src/wasm/compat/types/mod.rs
+++ b/src/wasm/compat/types/mod.rs
@@ -10,7 +10,7 @@ mod snapshot;
 pub use bucket::WasmBucket;
 pub use bucket_key::WasmBucketKey;
 pub use bucket_metadata::WasmBucketMetadata;
-pub use error::{to_js_error_with_debug, to_wasm_error_with_debug, TombWasmError};
+pub use error::{to_js_error_with_msg, to_wasm_error_with_msg, TombWasmError};
 pub use fs_metadata_entry::WasmFsMetadataEntry;
 pub use node_metadata::WasmNodeMetadata;
 pub use shared_file::WasmSharedFile;

--- a/src/wasm/compat/types/mod.rs
+++ b/src/wasm/compat/types/mod.rs
@@ -10,7 +10,7 @@ mod snapshot;
 pub use bucket::WasmBucket;
 pub use bucket_key::WasmBucketKey;
 pub use bucket_metadata::WasmBucketMetadata;
-pub use error::TombWasmError;
+pub use error::{to_js_error_with_debug, to_wasm_error, to_wasm_error_with_debug, TombWasmError};
 pub use fs_metadata_entry::WasmFsMetadataEntry;
 pub use node_metadata::WasmNodeMetadata;
 pub use shared_file::WasmSharedFile;

--- a/src/wasm/compat/types/node_metadata.rs
+++ b/src/wasm/compat/types/node_metadata.rs
@@ -13,7 +13,7 @@ impl TryFrom<JsValue> for WasmNodeMetadata {
     fn try_from(js_value: JsValue) -> Result<Self, Self::Error> {
         let object = js_value
             .dyn_into::<Object>()
-            .map_err(|_| TombWasmError("expected an object to be passed in".to_string()))?;
+            .map_err(|_| TombWasmError::new("expected an object to be passed in"))?;
 
         let mut map = BTreeMap::new();
 

--- a/src/wasm/compat/types/node_metadata.rs
+++ b/src/wasm/compat/types/node_metadata.rs
@@ -19,8 +19,8 @@ impl TryFrom<JsValue> for WasmNodeMetadata {
 
         // We know object is an Object already, so this shouldn't be able to panic (that is the
         // only documented way for this to throw an error).
-        let created_ref =
-            Reflect::get(&object, &JsValue::from_str("created")).expect("undocumented error");
+        let created_ref = Reflect::get(&object, &JsValue::from_str("created"))
+            .map_err(|_| TombWasmError::new("created property on object"))?;
         if let Some(timestamp) = created_ref.as_f64() {
             map.insert("created".into(), Ipld::Integer(timestamp as i128));
         } else {
@@ -28,8 +28,8 @@ impl TryFrom<JsValue> for WasmNodeMetadata {
         }
 
         // See created
-        let modified_ref =
-            Reflect::get(&object, &JsValue::from_str("created")).expect("undocumented error");
+        let modified_ref = Reflect::get(&object, &JsValue::from_str("created"))
+            .map_err(|_| TombWasmError::new("created property on object"))?;
         if let Some(timestamp) = modified_ref.as_f64() {
             map.insert("modified".into(), Ipld::Integer(timestamp as i128));
         } else {

--- a/src/wasm/compat/types/shared_file.rs
+++ b/src/wasm/compat/types/shared_file.rs
@@ -13,7 +13,7 @@ impl WasmSharedFile {
         Ok(self
             .0
             .export_b64_url()
-            .map_err(|_| TombWasmError(format!("Unable to export shared file as b64 url data")))?)
+            .map_err(|_| TombWasmError::new("Unable to export shared file as b64 url data"))?)
     }
 
     pub fn import_b64_url(b64_string: String) -> TombResult<WasmSharedFile> {

--- a/src/wasm/compat/types/shared_file.rs
+++ b/src/wasm/compat/types/shared_file.rs
@@ -1,4 +1,5 @@
 use crate::prelude::filesystem::sharing::SharedFile;
+use crate::wasm::compat::to_wasm_error_with_debug;
 use crate::wasm::{TombResult, TombWasmError};
 use std::ops::Deref;
 use wasm_bindgen::prelude::wasm_bindgen;
@@ -17,9 +18,8 @@ impl WasmSharedFile {
 
     pub fn import_b64_url(b64_string: String) -> TombResult<WasmSharedFile> {
         Ok(WasmSharedFile(
-            SharedFile::import_b64_url(b64_string).map_err(|_| {
-                TombWasmError(format!("Unable to import shared file from b64 url data"))
-            })?,
+            SharedFile::import_b64_url(b64_string)
+                .map_err(to_wasm_error_with_debug("import shared file from b64"))?,
         ))
     }
 

--- a/src/wasm/compat/types/shared_file.rs
+++ b/src/wasm/compat/types/shared_file.rs
@@ -1,6 +1,7 @@
-use crate::prelude::filesystem::sharing::SharedFile;
-use crate::wasm::compat::to_wasm_error_with_debug;
-use crate::wasm::{TombResult, TombWasmError};
+use crate::{
+    filesystem::sharing::SharedFile,
+    wasm::{to_wasm_error_with_debug, TombResult, TombWasmError},
+};
 use std::ops::Deref;
 use wasm_bindgen::prelude::wasm_bindgen;
 

--- a/src/wasm/compat/types/shared_file.rs
+++ b/src/wasm/compat/types/shared_file.rs
@@ -1,6 +1,6 @@
 use crate::{
     filesystem::sharing::SharedFile,
-    wasm::{to_wasm_error_with_debug, TombResult, TombWasmError},
+    wasm::{to_wasm_error_with_msg, TombResult, TombWasmError},
 };
 use std::ops::Deref;
 use wasm_bindgen::prelude::wasm_bindgen;
@@ -20,7 +20,7 @@ impl WasmSharedFile {
     pub fn import_b64_url(b64_string: String) -> TombResult<WasmSharedFile> {
         Ok(WasmSharedFile(
             SharedFile::import_b64_url(b64_string)
-                .map_err(to_wasm_error_with_debug("import shared file from b64"))?,
+                .map_err(to_wasm_error_with_msg("import shared file from b64"))?,
         ))
     }
 

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -4,8 +4,9 @@ mod compat;
 
 /// Expose all the compatibility types directly
 pub use compat::{
-    TombResult, TombWasm, TombWasmError, WasmBucket, WasmBucketKey, WasmBucketMetadata,
-    WasmFsMetadataEntry, WasmMount, WasmNodeMetadata, WasmSharedFile, WasmSnapshot,
+    to_wasm_error, TombResult, TombWasm, TombWasmError, WasmBucket, WasmBucketKey,
+    WasmBucketMetadata, WasmFsMetadataEntry, WasmMount, WasmNodeMetadata, WasmSharedFile,
+    WasmSnapshot,
 };
 
 /// Turn a value into a JsValue

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -4,9 +4,8 @@ mod compat;
 
 /// Expose all the compatibility types directly
 pub use compat::{
-    to_wasm_error, TombResult, TombWasm, TombWasmError, WasmBucket, WasmBucketKey,
-    WasmBucketMetadata, WasmFsMetadataEntry, WasmMount, WasmNodeMetadata, WasmSharedFile,
-    WasmSnapshot,
+    TombResult, TombWasm, TombWasmError, WasmBucket, WasmBucketKey, WasmBucketMetadata,
+    WasmFsMetadataEntry, WasmMount, WasmNodeMetadata, WasmSharedFile, WasmSnapshot,
 };
 
 /// Turn a value into a JsValue

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -4,8 +4,9 @@ mod compat;
 
 /// Expose all the compatibility types directly
 pub use compat::{
-    TombResult, TombWasm, TombWasmError, WasmBucket, WasmBucketKey, WasmBucketMetadata,
-    WasmFsMetadataEntry, WasmMount, WasmNodeMetadata, WasmSharedFile, WasmSnapshot,
+    to_js_error_with_debug, to_wasm_error_with_debug, TombResult, TombWasm, TombWasmError,
+    WasmBucket, WasmBucketKey, WasmBucketMetadata, WasmFsMetadataEntry, WasmMount,
+    WasmNodeMetadata, WasmSharedFile, WasmSnapshot,
 };
 
 /// Turn a value into a JsValue

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -4,9 +4,9 @@ mod compat;
 
 /// Expose all the compatibility types directly
 pub use compat::{
-    to_js_error_with_debug, to_wasm_error_with_debug, TombResult, TombWasm, TombWasmError,
-    WasmBucket, WasmBucketKey, WasmBucketMetadata, WasmFsMetadataEntry, WasmMount,
-    WasmNodeMetadata, WasmSharedFile, WasmSnapshot,
+    to_js_error_with_msg, to_wasm_error_with_msg, TombResult, TombWasm, TombWasmError, WasmBucket,
+    WasmBucketKey, WasmBucketMetadata, WasmFsMetadataEntry, WasmMount, WasmNodeMetadata,
+    WasmSharedFile, WasmSnapshot,
 };
 
 /// Turn a value into a JsValue


### PR DESCRIPTION
# Description
- Removed unwraps and excepts from the banyan-cli wasm submodule in all functions that already return a Result.
- wrote custom error mapping helper function to reduce code clutter.
- converted existing calls to use this helper.

## Link to issue
https://linear.app/banyan/issue/ENG-440/remove-unwraps-and-expects-from-wasm-calls

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactor (non-breaking change that updates existing functionality)
