### PR TITLE
Expose Remount / Bucket Refresh to WASM Clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,9 +1400,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",

--- a/src/api/requests/core/buckets/metadata/pull.rs
+++ b/src/api/requests/core/buckets/metadata/pull.rs
@@ -13,6 +13,7 @@ pub struct PullMetadata {
     pub bucket_id: Uuid,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub struct PullMetadataResponse(pub(crate) Vec<u8>);
 

--- a/src/api/requests/staging/pull_blocks.rs
+++ b/src/api/requests/staging/pull_blocks.rs
@@ -12,6 +12,7 @@ pub struct PullBlock {
     pub cid: Cid,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub struct PullBlockResponse(pub(crate) Vec<u8>);
 

--- a/src/wasm/compat/mod.rs
+++ b/src/wasm/compat/mod.rs
@@ -344,7 +344,6 @@ impl TombWasm {
     ///         or that has access to the bucket
     /// # Returns
     /// A WasmMount instance
-    #[wasm_bindgen(js_name = mount)]
     pub async fn mount(
         &mut self,
         bucket_id: String,

--- a/src/wasm/compat/mod.rs
+++ b/src/wasm/compat/mod.rs
@@ -344,6 +344,7 @@ impl TombWasm {
     ///         or that has access to the bucket
     /// # Returns
     /// A WasmMount instance
+    #[wasm_bindgen(js_name = mount)]
     pub async fn mount(
         &mut self,
         bucket_id: String,

--- a/src/wasm/compat/types/mount.rs
+++ b/src/wasm/compat/types/mount.rs
@@ -539,6 +539,17 @@ impl WasmMount {
         Ok(())
     }
 
+    /// Refreshes the bucket to ensure its up to date against what the server is aware of
+    pub async fn remount(&mut self, encryption_key_pem: String) -> Result<(), TombWasmError> {
+        let key = EcEncryptionKey::import(encryption_key_pem.as_bytes())
+            .await
+            .map_err(to_wasm_error_with_msg("import encryption key"))?;
+
+        self.refresh(&key).await?;
+
+        Ok(())
+    }
+
     /// Write a file
     /// # Arguments
     /// * `path_segments` - The path to write to (as an Array)

--- a/src/wasm/compat/types/mount.rs
+++ b/src/wasm/compat/types/mount.rs
@@ -155,6 +155,8 @@ impl WasmMount {
 
     /// Refresh the current fs_metadata with the remote
     pub async fn refresh(&mut self, key: &EcEncryptionKey) -> Result<(), TombWasmError> {
+        info!(bucket_id = ?self.bucket.id, "refresh");
+
         let bucket_id = self.bucket.id;
 
         // Get the metadata associated with the bucket
@@ -164,7 +166,7 @@ impl WasmMount {
 
         let metadata_cid = metadata.metadata_cid.clone();
         info!(
-            "pull()/{} - pulling metadata at version {}",
+            "refresh()/{} - pulling metadata at version {}",
             self.bucket.id.to_string(),
             metadata_cid
         );
@@ -173,10 +175,10 @@ impl WasmMount {
         let mut stream = metadata
             .pull(&mut self.client)
             .await
-            .map_err(to_wasm_error_with_msg("pull metadata"))?;
+            .map_err(to_wasm_error_with_msg("refresh metadata"))?;
 
         info!(
-            "pull()/{} - reading metadata stream",
+            "refresh()/{} - reading metadata stream",
             self.bucket.id.to_string()
         );
 
@@ -186,7 +188,7 @@ impl WasmMount {
         }
 
         info!(
-            "pull()/{} - creating metadata blockstore",
+            "refresh()/{} - creating metadata blockstore",
             self.bucket.id.to_string()
         );
 
@@ -195,16 +197,20 @@ impl WasmMount {
         let content_blockstore =
             BlockStore::new().map_err(to_wasm_error_with_msg("create blockstore"))?;
 
+        // does self.bucket need to be updated?
         self.metadata = Some(metadata.to_owned());
         self.metadata_blockstore = metadata_blockstore;
         self.content_blockstore = content_blockstore;
+        self.locked = true;
         self.dirty = false;
         self.append = false;
         self.fs_metadata = None;
+        self.previous_cid = Some(metadata_cid);
 
-        info!("pull()/{} - pulled", self.bucket.id.to_string());
+        info!("refresh()/{} - pulled", self.bucket.id.to_string());
         self.unlock(key).await?;
-        // Ok
+        info!("refresh()/{} - unlocked", self.bucket.id.to_string());
+
         Ok(())
     }
 
@@ -292,6 +298,7 @@ impl WasmMount {
         assert_eq!(metadata.metadata_cid, metadata_cid.to_string());
         let metadata_id = metadata.id;
         self.metadata = Some(metadata);
+        self.previous_cid = Some(metadata_cid.to_string());
 
         match (host, authorization) {
             // New storage ticket
@@ -541,11 +548,15 @@ impl WasmMount {
 
     /// Refreshes the bucket to ensure its up to date against what the server is aware of
     pub async fn remount(&mut self, encryption_key_pem: String) -> TombResult<()> {
+        info!(bucket_id = ?self.bucket.id, "remount");
+
         let key = EcEncryptionKey::import(encryption_key_pem.as_bytes())
             .await
             .map_err(|e| TombWasmError::new(&e.to_string()))?;
 
         self.refresh(&key).await?;
+
+        info!(bucket_id = ?self.bucket.id, "remount complete");
 
         Ok(())
     }

--- a/src/wasm/compat/types/mount.rs
+++ b/src/wasm/compat/types/mount.rs
@@ -540,10 +540,10 @@ impl WasmMount {
     }
 
     /// Refreshes the bucket to ensure its up to date against what the server is aware of
-    pub async fn remount(&mut self, encryption_key_pem: String) -> Result<(), TombWasmError> {
+    pub async fn remount(&mut self, encryption_key_pem: String) -> TombResult<()> {
         let key = EcEncryptionKey::import(encryption_key_pem.as_bytes())
             .await
-            .map_err(to_wasm_error_with_msg("import encryption key"))?;
+            .map_err(|e| TombWasmError::new(&e.to_string()))?;
 
         self.refresh(&key).await?;
 

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -4,9 +4,9 @@ mod compat;
 mod version;
 /// Expose all the compatibility types directly
 pub use compat::{
-    to_js_error_with_msg, to_wasm_error_with_msg, TombResult, TombWasm, TombWasmError, WasmBucket,
-    WasmBucketKey, WasmBucketMetadata, WasmBucketMount, WasmFsMetadataEntry, WasmMount,
-    WasmNodeMetadata, WasmSharedFile, WasmSnapshot,
+    to_wasm_error_with_msg, TombResult, TombWasm, TombWasmError, WasmBucket, WasmBucketKey,
+    WasmBucketMetadata, WasmBucketMount, WasmFsMetadataEntry, WasmMount, WasmNodeMetadata,
+    WasmSharedFile, WasmSnapshot,
 };
 use std::sync::Once;
 use time::macros::format_description;

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -48,7 +48,11 @@ pub fn register_log() {
             .with_writer(MakeWebConsoleWriter::new())
             .with_filter(fmt_filter);
 
-        let perf_filter = if cfg!(debug_assertions) { LevelFilter::DEBUG } else { LevelFilter::WARN };
+        let perf_filter = if cfg!(debug_assertions) {
+            LevelFilter::DEBUG
+        } else {
+            LevelFilter::INFO
+        };
         let perf_layer = performance_layer()
             .with_details_from_fields(Pretty::default())
             .with_filter(perf_filter);
@@ -62,11 +66,9 @@ pub fn register_log() {
         // Print info no matter what
         info!("new() with version {}", version());
 
-        if cfg!(debug_assertions) {
-            info!("logging is working. because you built in debug mode you should see all output.");
-        } else {
-            info!("logging is working, but because you have built for release, only errors and warnings will appear from here on out.");
-            let _ = fmt_handle.modify(|filter| *filter = LevelFilter::WARN);
+        if !cfg!(debug_assertions) {
+            info!("logging is restricted to informational and above in release mode");
+            let _ = fmt_handle.modify(|filter| *filter = LevelFilter::INFO);
         }
     });
 }


### PR DESCRIPTION
Exposes as `remount()` function on WasmMount objects that will pull the most recent metadata from the server and unlocking it in place to act as a bandaid for the 409 Conflict problem.

I'm not sure why the compiler started detecting a couple of the response types as dead code, I did confirm they were still present in code paths (it might be from different architectures).

I also tweaked the logging to give us a bit more detail right now of whats going on. It might give us better insights into the problem.